### PR TITLE
Update 11.parse.bas to support labels for the RESTORE statement

### DIFF
--- a/11.parse.bas
+++ b/11.parse.bas
@@ -247,7 +247,7 @@
  4002 if c$="0" thenc$=".":return        : rem stupid ms basic optimization
  4005 if tg and dz=0 thengosub4500:tg=0:return   : rem replace label
  4006 if c$="goto" thennl=1
- 4007 if c$="goto" or c$="gosub" or c$="trap" thentg=1
+ 4007 if c$="goto" or c$="gosub" or c$="trap" or c$="restore" thentg=1
  4008 dr=0 : rem did replace flag
  4009 if left$(c$,1)="$" thenhx$=mid$(c$,2):gosub4900:return
  4010 if left$(c$,1)="%" thenbi$=mid$(c$,2):gosub4800:return


### PR DESCRIPTION
The RESTORE statement to set the internal pointer for READ (token $8C) allows it to define the line number of the next read operation.

In Eleven this command with parameter made no sense, because we are not able to provide a (later given) line number and the Eleven pass 1 doesn't allow to set a label.

Modifying one if-statement allows to use labels. I tested compiling RESTORE with and w/o parameter.