### PR TITLE
Labels for on gosub goto

### DIFF
--- a/11.parse.bas
+++ b/11.parse.bas
@@ -247,7 +247,7 @@
  4002 if c$="0" thenc$=".":return        : rem stupid ms basic optimization
  4005 if tg and dz=0 thengosub4500:tg=0:return   : rem replace label
  4006 if c$="goto" thennl=1
- 4007 if c$="goto" or c$="gosub" or c$="trap" thentg=1
+ 4007 if c$="goto" or c$="gosub" or c$="trap" or c$="restore" thentg=1
  4008 dr=0 : rem did replace flag
  4009 if left$(c$,1)="$" thenhx$=mid$(c$,2):gosub4900:return
  4010 if left$(c$,1)="%" thenbi$=mid$(c$,2):gosub4800:return

--- a/11.parse.bas
+++ b/11.parse.bas
@@ -271,7 +271,10 @@
  4077 next id
  4078 if ci<>-1 then return:else if asc(c$)=222 then return:rem pi
  4079 if instr(dc$, lc$)<>0 and (c$="r" or c$="p" or c$="u8" or c$="w" or c$="l" or c$="u") then return
- 4080 pe$="?unresolved identifier: '"+c$+"' in line "+str$(sl):sleep 1:goto 1800
+ 4080 rem can use 'on x gosub/goto' if all labels are already defined earlier
+ 4081 pe$="@":gosub4505
+ 4082 pe$="":if dr=1 thenreturn
+ 4083 pe$="?unresolved identifier: '"+c$+"' in line "+str$(sl):sleep 1:goto 1800
  4090 return
  4091 :
  4092 :
@@ -283,7 +286,7 @@
  4510 for id=0 to lc-1
  4520 if c$=lb$(id) thenc$=str$(ll(id)):id=lc:dr=1
  4530 next id
- 4540 if dr thenreturn
+ 4540 if dr=1 or pe$="@" thenreturn
  4550 pe$="?unresolved label: '"+c$+"' in line"+str$(ln%(si-1)):sleep 1:goto1800
  4567 return
  4800 rem --- convert binary


### PR DESCRIPTION
We can not use 'on ... gosub / goto' in Eleven projects, because the second and further labels are not translated. They lead into an error.

The attached changes allow us to use the commands when the labels are already defined before the command usage, in the source code file.